### PR TITLE
Make API base configurable for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 dist
-.env
+/.env
 backend/node_modules
 frontend/node_modules
 frontend/dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
 
   frontend:
     build: ./frontend
+    environment:
+      VITE_API_BASE: /api
     depends_on:
       - backend
     ports:

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE=/api

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,11 +1,13 @@
+/* eslint-env node */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import process from 'node:process';
 
 export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:5000'
+      '/api': process.env.VITE_API_BASE || 'http://localhost:5000'
     }
   }
 });


### PR DESCRIPTION
## Summary
- allow Vite dev server to proxy using VITE_API_BASE with localhost fallback
- add VITE_API_BASE=/api to frontend env and docker-compose for relative production paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error in src/components/Scoreboard.jsx)*
- `docker-compose build frontend` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68bb564a1b688330baf55db39cdd7602