### PR TITLE
Add app.yaml for backend and frontend services

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,20 @@
+name: codex-app
+services:
+  - name: backend
+    source_dir: backend
+    dockerfile_path: backend/Dockerfile
+    environment_slug: node-js
+    build_command: npm install
+    run_command: npm start
+    envs:
+      - key: NODE_ENV
+        value: production
+  - name: frontend
+    source_dir: frontend
+    dockerfile_path: frontend/Dockerfile
+    environment_slug: node-js
+    build_command: npm install && npm run build
+    run_command: npm run preview
+    envs:
+      - key: VITE_API_URL
+        value: http://localhost:3000


### PR DESCRIPTION
## Summary
- add app.yaml defining backend and frontend services with build/run commands and env variables

## Testing
- `cd backend && npm test >/tmp/backend_test.log && cat /tmp/backend_test.log`
- `cd frontend && npm test >/tmp/frontend_test.log && cat /tmp/frontend_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bb5f405ddc83308efa7d6b23fffbde