### PR TITLE
Map frontend to container port 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     depends_on:
       - backend
     ports:
-      - "3000:3000"
+      - "3000:80"
 
 volumes:
   db-data:


### PR DESCRIPTION
## Summary
- serve frontend through nginx by exposing container port 80 on host port 3000

## Testing
- `docker compose up -d --build` *(fails: unknown shorthand flag: 'd' in -d)*
- `docker-compose up -d --build` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68bb9bbdde9c833099fc2562b6f533de